### PR TITLE
@version @author docblock tags removed

### DIFF
--- a/rpc/inc/example_config.inc.php
+++ b/rpc/inc/example_config.inc.php
@@ -26,8 +26,6 @@
  * Values stored in the $CONF[] array will be used
  *
  * @package RPC
- * @version $id$
- * @author Michael Berkowski <mjb@umn.edu>
  * to create the application's basic configuration.
  */
 

--- a/rpc/inc/rpc.inc.php
+++ b/rpc/inc/rpc.inc.php
@@ -26,8 +26,6 @@ require_once('rpc_user.inc.php');
  *
  * @abstract
  * @package RPC
- * @version $id$
- * @author Michael Berkowski <mjb@umn.edu>
  */
 abstract class RPC
 {

--- a/rpc/inc/rpc_assignment.inc.php
+++ b/rpc/inc/rpc_assignment.inc.php
@@ -28,8 +28,6 @@ require_once('rpc_user.inc.php');
  * Assignment as a complete project defined by a user
  *
  * @package RPC
- * @version $id$
- * @author Michael Berkowski <mjb@umn.edu>
  */
 class RPC_Assignment extends RPC_Assignment_Base
 {

--- a/rpc/inc/rpc_assignment_base.inc.php
+++ b/rpc/inc/rpc_assignment_base.inc.php
@@ -26,8 +26,6 @@ require_once('rpc_user.inc.php');
  * Base class for assignment and template objects
  *
  * @package RPC
- * @version $id$
- * @author Michael Berkowski <mjb@umn.edu>
  */
 abstract class RPC_Assignment_Base
 {

--- a/rpc/inc/rpc_config.inc.php
+++ b/rpc/inc/rpc_config.inc.php
@@ -30,8 +30,6 @@
  * Some values are created dynamically in the constructor
  *
  * @package RPC
- * @version $id$
- * @author Michael Berkowski <mjb@umn.edu>
  */
 
 require_once('rpc_version.inc.php');

--- a/rpc/inc/rpc_db.inc.php
+++ b/rpc/inc/rpc_db.inc.php
@@ -25,8 +25,6 @@
  * Database connection object singleton
  *
  * @package RPC
- * @version $id$
- * @author Michael Berkowski <mjb@umn.edu>
  */
 require_once('rpc_config.inc.php');
 class RPC_DB

--- a/rpc/inc/rpc_linked_assignment.inc.php
+++ b/rpc/inc/rpc_linked_assignment.inc.php
@@ -28,8 +28,6 @@ require_once('rpc_user.inc.php');
  * Assignment linked for users who don't own them
  *
  * @package RPC
- * @version $id$
- * @author Michael Berkowski <mjb@umn.edu>
  */
 class RPC_Linked_Assignment
 {	const ERR_NO_SUCH_OBJECT = 11;

--- a/rpc/inc/rpc_notification.inc.php
+++ b/rpc/inc/rpc_notification.inc.php
@@ -34,8 +34,6 @@ require_once('html2text.php');
  * code injection vulnerabilities.
  *
  * @package RPC
- * @version $id$
- * @author Michael Berkowski <mjb@umn.edu>
  */
 class RPC_Notification
 {

--- a/rpc/inc/rpc_smarty.inc.php
+++ b/rpc/inc/rpc_smarty.inc.php
@@ -33,8 +33,6 @@ require_once('rpc_user.inc.php');
  * Sets up basic common configurations and template variables
  *
  * @package RPC
- * @version $id$
- * @author Michael Berkowski <mjb@umn.edu>
  */
 class RPC_Smarty extends Smarty
 {

--- a/rpc/inc/rpc_step.inc.php
+++ b/rpc/inc/rpc_step.inc.php
@@ -26,8 +26,6 @@ require_once('rpc_step_base.inc.php');
  *
  * @uses RPC_Step_Base
  * @package RPC
- * @version $id$
- * @author Michael Berkowski <mjb@umn.edu>
  */
 class RPC_Step extends RPC_Step_Base
 {

--- a/rpc/inc/rpc_step_base.inc.php
+++ b/rpc/inc/rpc_step_base.inc.php
@@ -26,8 +26,6 @@
  *
  * @abstract
  * @package RPC
- * @version $id$
- * @author Michael Berkowski <mjb@umn.edu>
  */
 abstract class RPC_Step_Base
 {

--- a/rpc/inc/rpc_template.inc.php
+++ b/rpc/inc/rpc_template.inc.php
@@ -28,8 +28,6 @@ require_once('rpc_user.inc.php');
  * Assignment as a complete project defined by a user
  *
  * @package RPC
- * @version $id$
- * @author Michael Berkowski <mjb@umn.edu>
  */
 class RPC_Template extends RPC_Assignment_Base
 {

--- a/rpc/inc/rpc_user.inc.php
+++ b/rpc/inc/rpc_user.inc.php
@@ -24,8 +24,6 @@
  * Local user object
  * 
  * @package RPC
- * @version $id$
- * @author Michael Berkowski <mjb@umn.edu>
  */
 class RPC_User
 {

--- a/rpc/plugins/auth/native/native.inc.php
+++ b/rpc/plugins/auth/native/native.inc.php
@@ -24,7 +24,6 @@
  * Stores local users with passwords, using email address as username
  *
  * @package RPC
- * @author Michael Berkowski <mjb@umn.edu>
  */
 require_once('native_user.inc.php');
 /**

--- a/rpc/plugins/auth/native/native_user.inc.php
+++ b/rpc/plugins/auth/native/native_user.inc.php
@@ -26,7 +26,6 @@ require_once(dirname(__FILE__) . "/../../../inc/rpc_smarty.inc.php");
  * RPC users utilizing the 'native' authentication plugin
  *
  * @package RPC
- * @author Michael Berkowski <mjb@umn.edu>
  */
 class Native_User extends RPC_User
 {


### PR DESCRIPTION
`@version` tags are no longer used in Git (they weren't really used in SVN either for this project).  The `@author` tag is out of fashion, due to the clear public commit history Github offers.
